### PR TITLE
fix(ci): use git tag --points-at for reliable version extraction

### DIFF
--- a/actions/version/action.yml
+++ b/actions/version/action.yml
@@ -30,14 +30,16 @@ runs:
       working-directory: ${{ inputs.workdir }}
       run: |
         head_sha=$(git rev-parse HEAD)
-        tag_sha=$(git rev-list --tags --max-count=1 2>/dev/null || echo "")
-        tag_name=$(git describe --tags "$tag_sha" 2>/dev/null || echo "v0.1.0")
-        base_version=${tag_name#v}
 
-        if [ "$head_sha" = "$tag_sha" ]; then
+        exact_tag=$(git tag --points-at HEAD --sort=-v:refname | grep '^v' | head -n 1 || echo "")
+
+        if [ -n "$exact_tag" ]; then
+          base_version=${exact_tag#v}
           version="$base_version"
           channel="latest"
         else
+          latest_tag=$(git tag --sort=-v:refname | grep '^v' | head -n 1 || echo "v0.1.0")
+          base_version=${latest_tag#v}
           version="$base_version-$(git rev-parse --short HEAD)"
           channel="dev"
         fi


### PR DESCRIPTION
## Summary

- Replace unreliable `git rev-list --tags --max-count=1` + `git describe` with `git tag --points-at HEAD` to precisely detect whether HEAD carries a version tag
- Use `git tag --sort=-v:refname` for dev builds, avoiding commit-time ordering pitfalls that caused repeated npm publish failures (`You cannot publish over the previously published versions`)

## Test plan

- [ ] Push a `v*` tag to a Node project using this workflow, verify `channel=latest` and correct version
- [ ] Push to main without a tag, verify `channel=dev` and version includes short SHA suffix