### PR TITLE
ci(node): add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/ci-deploy-pages.yml
+++ b/.github/workflows/ci-deploy-pages.yml
@@ -1,0 +1,113 @@
+name: Deploy Node to GitHub Pages
+
+on:
+  workflow_call:
+    inputs:
+      workdir:
+        required: false
+        default: "./"
+        type: string
+        description: Working directory
+      node-version:
+        required: false
+        default: "lts/*"
+        type: string
+        description: Node.js version
+      build:
+        required: false
+        default: build
+        type: string
+        description: Build script name; set to empty to skip building
+      artifact-path:
+        required: false
+        default: dist
+        type: string
+        description: Static site output path relative to workdir
+      registry-url:
+        required: false
+        default: ""
+        type: string
+        description: npm registry URL for scoped package auth
+      environment:
+        required: false
+        default: github-pages
+        type: string
+        description: GitHub Pages deployment environment
+    outputs:
+      page-url:
+        value: ${{ jobs.deploy.outputs.page-url }}
+        description: Deployed GitHub Pages URL
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: heliannuuthus/hephaestus/actions/setup-pnpm@main
+        with:
+          workdir: ${{ inputs.workdir }}
+          node-version: ${{ inputs.node-version }}
+          registry-url: ${{ inputs.registry-url }}
+
+      - uses: actions/configure-pages@v5
+
+      - name: Build
+        if: inputs.build != ''
+        working-directory: ${{ inputs.workdir }}
+        run: pnpm ${{ inputs.build }}
+
+      - name: Resolve artifact path
+        id: artifact
+        shell: bash
+        env:
+          ARTIFACT_PATH: ${{ inputs.artifact-path }}
+          WORKDIR: ${{ inputs.workdir }}
+        run: |
+          set -euo pipefail
+
+          workdir="$WORKDIR"
+          case "$workdir" in
+            */) ;;
+            *) workdir="$workdir/" ;;
+          esac
+
+          artifact_path="$ARTIFACT_PATH"
+          case "$artifact_path" in
+            /*) resolved="$artifact_path" ;;
+            *) resolved="$workdir$artifact_path" ;;
+          esac
+
+          if [ ! -d "$resolved" ]; then
+            echo "::error::GitHub Pages artifact path does not exist: $resolved"
+            exit 1
+          fi
+
+          echo "path=$resolved" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ steps.artifact.outputs.path }}
+
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page-url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.github/workflows/ci-rust-tauri.yml
+++ b/.github/workflows/ci-rust-tauri.yml
@@ -56,7 +56,7 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libwebkit2gtk-4.1-dev libglib2.0-dev libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-          version: rust-tauri-ci
+          version: rust-tauri-ci-v2
           execute_install_scripts: true
 
       - uses: heliannuuthus/hephaestus/actions/setup-pnpm@main

--- a/.github/workflows/ci-rust-tauri.yml
+++ b/.github/workflows/ci-rust-tauri.yml
@@ -53,11 +53,15 @@ jobs:
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libwebkit2gtk-4.1-dev libglib2.0-dev libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-          version: rust-tauri-ci-v2
-          execute_install_scripts: true
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libayatana-appindicator3-dev \
+            libglib2.0-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev
 
       - uses: heliannuuthus/hephaestus/actions/setup-pnpm@main
         with:

--- a/.github/workflows/ci-rust-tauri.yml
+++ b/.github/workflows/ci-rust-tauri.yml
@@ -55,7 +55,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libwebkit2gtk-4.1-dev libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+          packages: libwebkit2gtk-4.1-dev libglib2.0-dev libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
           version: rust-tauri-ci
           execute_install_scripts: true
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ actions/                          # Composite Actions (reusable steps)
 ├── ci-rust.yml                   # setup → lint → build
 ├── ci-node.yml                   # setup → lint → build (backend)
 ├── ci-frontend.yml               # setup → lint → build (frontend)
+├── ci-deploy-pages.yml           # pnpm build → GitHub Pages deploy
 ├── ci-rust-tauri.yml             # multi-platform Tauri build
 └── ci-containerize.yml           # Docker containerization
 ```
@@ -69,6 +70,21 @@ jobs:
     uses: heliannuuthus/hephaestus/.github/workflows/ci-frontend.yml@main
     with:
       workdir: "./"
+```
+
+### Frontend GitHub Pages Deploy
+
+```yaml
+jobs:
+  deploy:
+    uses: heliannuuthus/hephaestus/.github/workflows/ci-deploy-pages.yml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    with:
+      workdir: "./"
+      artifact-path: dist
 ```
 
 ### Node.js Backend


### PR DESCRIPTION
## Summary
- add a reusable Node/pnpm GitHub Pages deploy workflow
- build frontend projects with the existing setup-pnpm action
- upload the configured static artifact and deploy with GitHub Pages
- document the workflow in README

Closes #17

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci-deploy-pages.yml`
