### PR TITLE
ci(workflows): extend reusable delivery controls

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -18,11 +18,21 @@ on:
         default: build
         type: string
         description: Build script name
+      type-check:
+        required: false
+        default: ""
+        type: string
+        description: Type-check script name; set to empty to skip type checking
       test:
         required: false
         default: ""
         type: string
         description: Test script name
+      pack:
+        required: false
+        default: false
+        type: boolean
+        description: Run pnpm pack after a successful build
       registry-url:
         required: false
         default: ""
@@ -59,6 +69,10 @@ jobs:
         run: |
           pnpm lint
           pnpm format:check
+      - name: Type check
+        if: inputs.type-check != ''
+        working-directory: ${{ inputs.workdir }}
+        run: pnpm ${{ inputs.type-check }}
 
   build:
     needs: [lint]
@@ -83,6 +97,10 @@ jobs:
         if: inputs.test != ''
         working-directory: ${{ inputs.workdir }}
         run: pnpm ${{ inputs.test }}
+      - name: Pack
+        if: inputs.pack
+        working-directory: ${{ inputs.workdir }}
+        run: pnpm pack --pack-destination "$RUNNER_TEMP"
       - uses: heliannuuthus/hephaestus/actions/version@main
         id: version
         with:

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -18,11 +18,26 @@ on:
         default: build
         type: string
         description: Build script name
+      format-check:
+        required: false
+        default: ""
+        type: string
+        description: Format-check script name; set to empty to skip
+      type-check:
+        required: false
+        default: ""
+        type: string
+        description: Type-check script name; set to empty to skip
       test:
         required: false
         default: ""
         type: string
         description: Test script name
+      pack:
+        required: false
+        default: false
+        type: boolean
+        description: Run pnpm pack after a successful build
       registry-url:
         required: false
         default: ""
@@ -57,6 +72,14 @@ jobs:
       - name: Lint
         working-directory: ${{ inputs.workdir }}
         run: pnpm lint
+      - name: Format check
+        if: inputs.format-check != ''
+        working-directory: ${{ inputs.workdir }}
+        run: pnpm ${{ inputs.format-check }}
+      - name: Type check
+        if: inputs.type-check != ''
+        working-directory: ${{ inputs.workdir }}
+        run: pnpm ${{ inputs.type-check }}
 
   build:
     needs: [lint]
@@ -81,6 +104,10 @@ jobs:
         if: inputs.test != ''
         working-directory: ${{ inputs.workdir }}
         run: pnpm ${{ inputs.test }}
+      - name: Pack
+        if: inputs.pack
+        working-directory: ${{ inputs.workdir }}
+        run: pnpm pack --pack-destination "$RUNNER_TEMP"
       - uses: heliannuuthus/hephaestus/actions/version@main
         id: version
         with:

--- a/.github/workflows/ci-publish-node.yml
+++ b/.github/workflows/ci-publish-node.yml
@@ -54,4 +54,11 @@ jobs:
 
       - name: Publish
         working-directory: ${{ inputs.workdir }}
-        run: pnpm publish --no-git-checks --access public --provenance --tag ${{ steps.version.outputs.channel }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            unset NODE_AUTH_TOKEN
+          fi
+
+          pnpm publish --no-git-checks --access public --provenance --tag ${{ steps.version.outputs.channel }}

--- a/.github/workflows/ci-rust-tauri.yml
+++ b/.github/workflows/ci-rust-tauri.yml
@@ -28,11 +28,14 @@ on:
         default: ""
         type: string
         description: Frontend test command
+      release:
+        required: false
+        default: true
+        type: boolean
+        description: Create a draft GitHub Release; set false for build-only CI
 
 jobs:
   build-tauri:
-    permissions:
-      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -97,9 +100,9 @@ jobs:
         with:
           tauriScript: pnpm tauri
           projectPath: ${{ inputs.workdir }}
-          tagName: ${{ steps.version.outputs.project }}-v__VERSION__
-          releaseName: "${{ steps.version.outputs.project }} v__VERSION__"
-          releaseBody: ${{ github.event.head_commit.message }}
-          releaseDraft: true
+          tagName: ${{ inputs.release && format('{0}-v__VERSION__', steps.version.outputs.project) || '' }}
+          releaseName: ${{ inputs.release && format('{0} v__VERSION__', steps.version.outputs.project) || '' }}
+          releaseBody: ${{ inputs.release && github.event.head_commit.message || '' }}
+          releaseDraft: ${{ inputs.release }}
           prerelease: false
           args: --target ${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ actions/                          # Composite Actions (reusable steps)
 ├── ci-golang.yml                 # setup → lint → security → build
 ├── ci-rust.yml                   # setup → lint → build
 ├── ci-node.yml                   # setup → lint → build (backend)
-├── ci-frontend.yml               # setup → lint → build (frontend)
+├── ci-frontend.yml               # setup → lint/type-check → build/test/pack
 ├── ci-deploy-pages.yml           # pnpm build → GitHub Pages deploy
 ├── ci-rust-tauri.yml             # multi-platform Tauri build
 └── ci-containerize.yml           # Docker containerization
@@ -70,7 +70,13 @@ jobs:
     uses: heliannuuthus/hephaestus/.github/workflows/ci-frontend.yml@main
     with:
       workdir: "./"
+      type-check: type-check
+      pack: true
 ```
+
+`type-check`, `test`, and `pack` are opt-in so applications and publishable
+packages can share the same workflow. `type-check` and `test` name package
+scripts; `pack: true` validates the publishable tarball with `pnpm pack`.
 
 ### Frontend GitHub Pages Deploy
 
@@ -95,7 +101,28 @@ jobs:
     uses: heliannuuthus/hephaestus/.github/workflows/ci-node.yml@main
     with:
       workdir: "./"
+      format-check: format:check
+      type-check: type-check
+      test: test
+      pack: true
 ```
+
+### Node.js Package Publish
+
+```yaml
+jobs:
+  publish:
+    uses: heliannuuthus/hephaestus/.github/workflows/ci-publish-node.yml@main
+    permissions:
+      contents: read
+      id-token: write
+```
+
+The publish job uses the caller repository's `publish` environment. For a new
+package, temporarily add `NPM_TOKEN` to that environment to bootstrap the first
+release. Afterward, configure npm Trusted Publishing with the caller workflow
+filename and the `publish` environment, then remove the token. When no token is
+present, npm authenticates through GitHub OIDC.
 
 ### Rust Tauri
 
@@ -104,8 +131,18 @@ jobs:
   ci:
     uses: heliannuuthus/hephaestus/.github/workflows/ci-rust-tauri.yml@main
     permissions:
-      contents: write
-      packages: write
+      contents: read
     with:
       workdir: "./"
+      release: false
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [ci]
+    uses: heliannuuthus/hephaestus/.github/workflows/ci-rust-tauri.yml@main
+    permissions:
+      contents: write
+    with:
+      workdir: "./"
+      release: true
 ```


### PR DESCRIPTION
## Summary

- Add opt-in type checking and package validation to the frontend reusable workflow.
- Add format checking, type checking, tests, and package validation inputs to the Node reusable workflow.
- Split Tauri build-only CI from release creation and support npm bootstrap credentials while preserving OIDC publishing.
- Document the new reusable workflow inputs and least-privilege caller patterns.

## Test plan

- [x] Parse the four modified workflow files with Ruby Psych.
- [x] Review workflow inputs, permissions, release conditions, and documentation examples.

## Notes

- actionlint was unavailable in the local environment.